### PR TITLE
FIX mapping of typecodes in npsupport

### DIFF
--- a/comtypes/npsupport.py
+++ b/comtypes/npsupport.py
@@ -86,15 +86,15 @@ def _check_ctypeslib_typecodes():
     except ImportError:
         from numpy.ctypeslib import as_ctypes_type
 
-        ctypes_to_dtypes = {}
+        dtypes_to_ctypes = {}
 
         for tp in set(np.sctypeDict.values()):
             try:
                 ctype_for = as_ctypes_type(tp)
-                ctypes_to_dtypes[ctype_for] = tp
+                dtypes_to_ctypes[np.dtype(tp).str] = ctype_for
             except NotImplementedError:
                 continue
-        ctypeslib._typecodes = ctypes_to_dtypes
+        ctypeslib._typecodes = dtypes_to_ctypes
     return ctypeslib._typecodes
 
 


### PR DESCRIPTION
In newer versions of numpy the ctypeslib._typecodes variable is no longer present, so comtypes populates it itself if it is not found. Previously the created dictionary was a mapping of ctypes classes to numpy dtypes, whereas the previous _typecodes dictionary mapped numpy dtype string representations to ctypes classes. This fix rearranges the mapping in the dictionary to be consistent with the previous format.

Closes #238